### PR TITLE
Allow modules with both `include` and `sub-module` elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic_include_protos"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ssankko <literaamr@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,35 +2,10 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use std::collections::HashMap;
 
-#[derive(Debug)]
-enum TreeEntry {
-    Node(String),
-    Branch(HashMap<String, Box<TreeEntry>>),
-}
-
-impl TreeEntry {
-    fn get_mut(&mut self, part: &str) -> Option<&mut Box<TreeEntry>> {
-        match self {
-            TreeEntry::Branch(tree) => tree.get_mut(part),
-            _ => panic!(),
-        }
-    }
-
-    fn get(&mut self, part: &str) -> Option<&Box<TreeEntry>> {
-        match self {
-            TreeEntry::Branch(tree) => tree.get(part),
-            _ => panic!(),
-        }
-    }
-
-    fn insert(&mut self, part: String, node: TreeEntry) {
-        match self {
-            TreeEntry::Branch(tree) => {
-                tree.insert(part, Box::new(node));
-            }
-            _ => panic!(),
-        }
-    }
+#[derive(Default, Debug)]
+struct ModuleStructure {
+    pub mod_file: Option<String>,
+    pub children_modules: HashMap<String, Box<ModuleStructure>>,
 }
 
 /// Include all generated proto server and client items.
@@ -78,7 +53,7 @@ pub fn include_protos(_item: TokenStream) -> TokenStream {
     // --------
     // traverse all files and construct tree-like structure of namespaces
     // --------
-    let mut tree = TreeEntry::Branch(Default::default());
+    let mut tree = ModuleStructure::default();
     for file_name in file_names {
         let mut current_branch = &mut tree;
         // split names by dot.
@@ -87,36 +62,37 @@ pub fn include_protos(_item: TokenStream) -> TokenStream {
         // [google, logging, v2, rs]
         for part in file_name.split('.') {
             if part == "rs" {
-                *current_branch = TreeEntry::Node(file_name.to_string());
+                current_branch.mod_file = Some(file_name.to_owned());
                 continue;
             }
 
-            if let None = current_branch.get(part) {
-                current_branch.insert(part.to_owned(), TreeEntry::Branch(Default::default()));
+            if current_branch.children_modules.get(part).is_none() {
+                current_branch
+                    .children_modules
+                    .insert(part.to_owned(), Box::new(ModuleStructure::default()));
             }
-            current_branch = current_branch.get_mut(part).unwrap();
+            current_branch = current_branch.children_modules.get_mut(part).unwrap();
         }
     }
     // --------
 
     // simple recursive function to construct mod tree based on a
     // tree built earlier
-    fn construct(tree_entry: Box<TreeEntry>, result: &mut String, out_dir: &str) {
-        match *tree_entry {
-            TreeEntry::Node(node) => {
-                result.push_str(&format!(r#"include!("{}/{}");"#, out_dir, node));
-            }
-            TreeEntry::Branch(branch) => {
-                for (name, child) in branch {
-                    result.push_str(&format!("pub mod {} {{", name));
-                    construct(child, result, out_dir);
-                    result.push_str("}");
-                }
-            }
-        }
+    fn construct(tree_entry: Box<ModuleStructure>, out_dir: &str) -> String {
+        format!(
+            "{}{}",
+            if let Some(i) = tree_entry.mod_file {
+                format!(r#"include!("{}/{}");"#, out_dir, i)
+            } else {
+                String::new()
+            },
+            tree_entry
+                .children_modules
+                .into_iter()
+                .map(|x| format!("pub mod {} {{ {} }}", x.0, construct(x.1, out_dir)))
+                .collect::<String>()
+        )
     }
 
-    let mut result = String::new();
-    construct(Box::new(tree), &mut result, &out_dir);
-    result.parse().unwrap()
+    construct(Box::new(tree), &out_dir).parse().unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub fn include_protos(_item: TokenStream) -> TokenStream {
                 }
             }
         }
-    };
+    }
 
     let mut result = String::new();
     construct(Box::new(tree), &mut result, &out_dir);


### PR DESCRIPTION
Protos with a package name (like `hello.world`) can have both definitions (in file `hello.world.rs`) and sub-protos (like `hello.world.connect` in file `hello.world.connect.rs`). [V2Ray](https://github.com/v2ray/v2ray-core) contains such protos. Therefore, the structure of the `Tree` is modified to implement this.